### PR TITLE
Fix reapPolicy wrong default value + Refactor ObjectDefParser2

### DIFF
--- a/src/com/ms/silverking/cloud/dht/daemon/DHTNodeOptions.java
+++ b/src/com/ms/silverking/cloud/dht/daemon/DHTNodeOptions.java
@@ -19,7 +19,7 @@ public class DHTNodeOptions {
     public int inactiveNodeTimeoutSeconds = defaultInactiveNodeTimeoutSeconds;
     
 	@Option(name="-reapPolicy", usage="reapPolicy", required=false)
-	String reapPolicy = new ReapOnIdlePolicy().toString();
+	String reapPolicy = ObjectDefParser2.toClassAndDefString(new ReapOnIdlePolicy());
 	
 	public ReapPolicy getReapPolicy() {
 		return (ReapPolicy)ObjectDefParser2.parse(reapPolicy, ReapPolicy.class.getPackage());

--- a/src/com/ms/silverking/text/ObjectDefParser2.java
+++ b/src/com/ms/silverking/text/ObjectDefParser2.java
@@ -102,7 +102,7 @@ public class ObjectDefParser2 {
     }
     
     public static String toClassAndDefString(Object o) {
-    	return "<"+ o.getClass().getCanonicalName() +">{"+ o.toString() +"}";	
+    	return "<"+ o.getClass().getCanonicalName() +">{"+ ObjectDefParser2.objectToString(o) +"}";
     }
     
 	private static Pair<Class,String> getClassAndDef(String nameAndDef, Package defaultPackage) {

--- a/test/com/ms/silverking/cloud/dht/daemon/DHTNodeOptionsReflectionTest.java
+++ b/test/com/ms/silverking/cloud/dht/daemon/DHTNodeOptionsReflectionTest.java
@@ -1,0 +1,39 @@
+package com.ms.silverking.cloud.dht.daemon;
+
+import com.ms.silverking.cloud.dht.daemon.storage.LRUReapPolicy;
+import com.ms.silverking.cloud.dht.daemon.storage.NeverReapPolicy;
+import com.ms.silverking.cloud.dht.daemon.storage.ReapOnIdlePolicy;
+import com.ms.silverking.cloud.dht.daemon.storage.ReapPolicy;
+import com.ms.silverking.text.ObjectDefParser2;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class DHTNodeOptionsReflectionTest {
+    @Test
+    public void testReapPolicyReflection() {
+        DHTNodeOptions options = new DHTNodeOptions();
+        // All these ReapPolicies override its toString as "ObjectDefParser2.objectToString(this)"
+        ReapPolicy p1 = new LRUReapPolicy();
+        ReapPolicy p2 = new LRUReapPolicy(true, true, false, 1000, 2000, 3000);
+        ReapPolicy p3 = new ReapOnIdlePolicy();
+        ReapPolicy p4 = new ReapOnIdlePolicy(true, true, false, true, false, 1000, 500, 999, 777, 78, 182, ReapPolicy.EmptyTrashMode.BeforeAndAfterInitialReap);
+
+        ReapPolicy[] policyTestSet1 = {p1, p2, p3, p4};
+        for(ReapPolicy policy: policyTestSet1) {
+            options.reapPolicy = ObjectDefParser2.toClassAndDefString(policy);
+            ReapPolicy reflectedPolicy = options.getReapPolicy();
+
+            System.out.println(policy.toString());
+            System.out.println(reflectedPolicy.toString());
+            assertEquals(policy.toString(), reflectedPolicy.toString());
+        }
+
+
+        // Only this policy does NOT override its toString
+        ReapPolicy p5 = new NeverReapPolicy();
+        options.reapPolicy = ObjectDefParser2.toClassAndDefString(p5);
+        assertTrue(options.getReapPolicy() instanceof NeverReapPolicy);
+    }
+}


### PR DESCRIPTION
Fix a trivial typo (the default value of `DHTNodeOptions.reapPolicy` shall be the `SKDef` format of `<ClassName>{arg1=val1, arg2=val2, ...}`

Regarding the recent merged change: https://github.com/Morgan-Stanley/SilverKing/commit/cd5af478e4d19fac7d21c3f96f9a96f31cbfeab2

@bh-ms @gjms 
